### PR TITLE
Various updates

### DIFF
--- a/gfcbuild.sql
+++ b/gfcbuild.sql
@@ -1,5 +1,5 @@
 rem gfcbuild.sql
-rem (c) Go-Faster Consultancy Ltd.
+rem (c) Go-Faster Consultancy
 clear screen
 
 spool gfcbuild

--- a/gfcbuildone.sql
+++ b/gfcbuildone.sql
@@ -1,5 +1,5 @@
 rem gfcbuildone.sql
-rem (c) Go-Faster Consultancy Ltd.
+rem (c) Go-Faster Consultancy 2021
 clear screen
 
 spool gfcbuild

--- a/gfcbuildpkg.sql
+++ b/gfcbuildpkg.sql
@@ -1,11 +1,14 @@
 rem gfcbuildpkg.sql
-rem (c) Go-Faster Consultancy Ltd.
+rem (c) Go-Faster Consultancy 
 
 spool gfcbuildpkg
 
 set serveroutput on buffer 1000000000 verify on feedback on lines 120 timing off autotrace off pause off echo off termout on
+
+@@ownerid
+
 ALTER SESSION SET recyclebin = off;
-ALTER SESSION SET current_schema=SYSADM;
+ALTER SESSION SET current_schema=&&ownerid;
 --set echo on
 
 --@@gfcbuildtab.sql--removed 1.11.2012 because it could cause accidental loss of additional privileges on metadata tables
@@ -13,7 +16,7 @@ ALTER SESSION SET current_schema=SYSADM;
 -----------------------------------------------------------------------------------------------------------
 --now build the package
 -----------------------------------------------------------------------------------------------------------
-CREATE OR REPLACE PACKAGE sysadm.gfc_pspart AS
+CREATE OR REPLACE PACKAGE &&ownerid..gfc_pspart AS
 
 -----------------------------------------------------------------------------------------------------------
 --Version and Copyright banner
@@ -43,6 +46,7 @@ PROCEDURE set_defaults
 ,p_logging         VARCHAR2 DEFAULT ''
 ,p_parallel_table  VARCHAR2 DEFAULT ''
 ,p_parallel_index  VARCHAR2 DEFAULT ''
+,p_force_ddl_dop   VARCHAR2 DEFAULT ''
 ,p_roles           VARCHAR2 DEFAULT ''
 ,p_scriptid        VARCHAR2 DEFAULT ''
 ,p_update_all      VARCHAR2 DEFAULT ''

--- a/gfcbuildpriv.sql
+++ b/gfcbuildpriv.sql
@@ -1,5 +1,6 @@
 --------------------------------------------------------------------------------------
---
+-- rem (c) Go-Faster Consultancy
+--------------------------------------------------------------------------------------
 -- script        : gfcbuildpriv.sql
 --
 -- created by    : David Kurtz
@@ -14,27 +15,26 @@
 -- date           author            version   reference           description
 -- ------------   ----------------- -------   ------------        --------------------
 -- 10.01.2013     David Kurtz       1.01                          Added privileges required by metadata package
+-- 25.06.2021                       1.02                          Extract ownerid from ps.psdbowner
 --------------------------------------------------------------------------------------
-
-rem (c) Go-Faster Consultancy Ltd.
-
 spool gfcbuildpriv
+set echo on
+@@ownerid
+--------------------------------------------------------------------------------------
+GRANT CREATE ANY CONTEXT TO &&ownerid;
 
-GRANT CREATE ANY CONTEXT TO sysadm;
+GRANT SELECT ON ps.psdbowner TO &&ownerid;
 
-GRANT SELECT ON ps.psdbowner TO sysadm;
-
-GRANT SELECT ON sys.v_$session TO sysadm;
-GRANT SELECT ON sys.v_$parameter TO sysadm;
-GRANT SELECT ON sys.v_$version TO sysadm;
-GRANT SELECT ON sys.dba_tables TO sysadm;
-GRANT SELECT ON sys.dba_tab_partitions TO sysadm;
-GRANT SELECT ON sys.dba_ind_partitions TO sysadm;
+GRANT SELECT ON sys.v_$session TO &&ownerid;
+GRANT SELECT ON sys.v_$parameter TO &&ownerid;
+GRANT SELECT ON sys.v_$version TO &&ownerid;
+GRANT SELECT ON sys.dba_tables TO &&ownerid;
+GRANT SELECT ON sys.dba_tab_partitions TO &&ownerid;
+GRANT SELECT ON sys.dba_ind_partitions TO &&ownerid;
 
 --10.1.2013 added privileges requird by metadata package
-GRANT SELECT on sys.dba_tablespaces    TO sysadm;
-GRANT SELECT on sys.dba_objects        TO sysadm;
-
-
+GRANT SELECT on sys.dba_tablespaces    TO &&ownerid;
+GRANT SELECT on sys.dba_objects        TO &&ownerid;
+--------------------------------------------------------------------------------------
 spool off
 

--- a/gfcbuildspool.sql
+++ b/gfcbuildspool.sql
@@ -1,9 +1,9 @@
 rem gfcbuildspool.sql
-rem (c) Go-Faster Consultancy Ltd.
+rem (c) Go-Faster Consultancy
 rem 17.9.2008 - moved spool commands from gfcbuild.sql to this script 
 
 column line format a254
-set timi off head off feedback off echo off verify off pages 0 lines 1024 trimspool on
+set timi off head off feedback off echo off verify off pages 0 lines 1024 trimspool on sqlblanklines on
 set termout off
 
 column SPOOL_FILENAME   new_value SPOOL_FILENAME

--- a/parthistfreq.sql
+++ b/parthistfreq.sql
@@ -1,0 +1,59 @@
+REM parthistfreq.sql
+set pages 999 lines 200 trimspool on 
+column table_name format a18
+column column_name format a20
+column endpoint_actual_value format a20
+column pct format 999.9
+column seq heading '#' format 999
+column column_position heading 'Col|Pos' format a3
+column freq     format 9,999,999,999
+column num_rows format 9,999,999,999
+column est_rows format 9,999,999,999
+break on table_name skip 1 on num_rows on parttype on column_position on column_name skip 1 on ledger_type
+compute sum of freq on column_name
+compute sum of est_rows on column_name
+spool parthistfreq
+with r as (
+select r.recname
+,      DECODE(r.sqltablename,' ','PS_'||r.recname,r.sqltablename) table_name
+,      t.ledger_type, t.ledger_template
+from   psrecdefn r
+  LEFT OUTER JOIN ps_led_tmplt_tbl t
+  ON   r.recname = t.recname
+--AND NOT t.ledger_template IN('TST','BUDGET_DLJ')
+WHERE  r.rectype = 0
+and    (  r.recname IN('LEDGER','LEDGER_BUDG')
+       OR t.ledger_type = 'S')
+), k as (
+select	'PARTITION' parttype, name, column_name, column_position||'/'||count(*) over (partition by object_type, name) column_position
+from 	user_part_key_columns
+where 	object_type = 'TABLE'
+UNION ALL
+select	'SUBPARTITION', name, column_name, column_position||'/'||count(*) over (partition by object_type, name) column_position
+from 	user_subpart_key_columns
+where 	object_type = 'TABLE'
+), x as (
+select r.ledger_type, h.table_name, t.num_rows, k.parttype, h.column_name
+, k.column_position
+, row_number() over (partition by h.table_name, h.column_name order by h.endpoint_number) seq
+, NVL(h.ENDPOINT_ACTUAL_VALUE,'<NULL>') ENDPOINT_ACTUAL_VALUE
+, h.endpoint_number-NVL(lag(h.endpoint_number,1) over (partition by h.table_name, h.column_name order by h.endpoint_number),0) freq
+from   user_tables t
+  LEFT JOIN r ON r.table_name = t.table_name
+,     user_Tab_histograms h
+  LEFT OUTER JOIN k
+  ON k.name = h.table_name
+  AND k.column_name = h.column_name
+where ( (h.column_name IN('LEDGER','FISCAL_YEAR','ACCOUNTING_PERIOD') AND (r.ledger_type IS NOT NULL OR r.recname like 'LEDGER%'))
+      OR k.column_name IS NOT NULL)
+and   h.table_name = t.table_name
+and   (r.recname IS NOT NULL OR t.partitioned = 'YES')
+)
+select x.*
+, 100*ratio_to_report(freq) over (partition by table_name, column_name) pct
+, num_rows*ratio_to_report(freq) over (partition by table_name, column_name) est_rows
+from x
+order by ledger_type nulls last, table_name, column_position nulls first, column_name, seq
+--fetch first 50 rows only
+/
+spool off

--- a/psownerid.sql
+++ b/psownerid.sql
@@ -1,0 +1,9 @@
+REM psownerid.sql
+
+column ownerid new_value ownerid
+select distinct ownerid 
+from ps.psdbowner p
+  left outer join v$database d on p.dbname = d.name
+order by d.name nulls last
+fetch first 1 row only
+/


### PR DESCRIPTION
1. Change PeopleSoft owner from SYSADM to a variable populated by psownerid.sql
2. Enhancements for range-range composite partitioning.  New metadata columns and triggers for backward compatibility
3. Additional parameters to specify DoP for forced parallel DDL
4. Histogram analysis query for candidate partitioned tables

This set of updates have been tested to PT8.58 and Oracle 19c.